### PR TITLE
Simplify keymaps

### DIFF
--- a/plugin/husk.vim
+++ b/plugin/husk.vim
@@ -28,42 +28,26 @@ function! s:enable_husk()
     cnoremap <expr> <C-k> husk#clear_line_after_cursor()
   endif
 
-  if has('gui_running') || has('nvim')
-    cnoremap <expr> <M-d> husk#del_word()
-    cnoremap <expr> <M-b> husk#left()
-    cnoremap <expr> <M-f> husk#right()
-    cnoremap <M-BS> <C-w>
-    cnoremap <expr> <M-#> "\<Home>\"\<CR>"
-  else
-    silent! exe "set <F30>=\<Esc>d"
-    silent! exe "set <F31>=\<Esc>\<C-?>"
-    silent! exe "set <F32>=\<Esc>\<C-h>"
-    silent! exe "set <F33>=\<Esc>b"
-    silent! exe "set <F34>=\<Esc>f"
-    silent! exe "set <F35>=\<Esc>#"
+  if !has('gui_running') && !has('nvim')
+    cmap <Esc>d <M-d>
+    cmap <Esc>b <M-b>
+    cmap <Esc>f <M-f>
+    cmap <Esc># <M-#>
+    cmap <Esc><C-?> <M-BS>
+    cmap <Esc><C-h> <M-BS>
+    cmap <Esc><BS> <M-BS>
 
-    " insert mode mappings that prevent errors in macros, see issue #4
-    inoremap <F30> <Esc>d
-    inoremap <F31> <Esc><C-?>
-    inoremap <F32> <Esc><C-h>
-    inoremap <F33> <Esc>b
-    inoremap <F34> <Esc>f
-    inoremap <F35> <Esc>#
-
-    cnoremap <expr> <F30> husk#del_word()
-    cnoremap <F31> <C-w>
-    cnoremap <F32> <C-w>
-    cnoremap <expr> <F33> husk#left()
-    cnoremap <expr> <F34> husk#right()
-    cnoremap <expr> <F35> "\<Home>\"\<CR>"
+    cnoremap <nowait> <expr> <Esc> stridx(&cpo, 'x') < 0 ? "\<C-c>" : "\<Esc>"
   endif
+
+  cnoremap <expr> <M-d> husk#del_word()
+  cnoremap <expr> <M-b> husk#left()
+  cnoremap <expr> <M-f> husk#right()
+  cnoremap <expr> <M-#> "\<Home>\"\<CR>"
+  cnoremap <M-BS> <C-w>
 endfunction
 
 call <SID>enable_husk()
-
-" When '&term' changes values for '<F3x>' options are reset.
-" Below autocmd restores values for those options when '&term' changes.
-au TermChanged * call <SID>enable_husk()
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
`<C-M-h>` does not work in gvim (`<88>` is displayed -- don't know whether that code is universal across keyboard layouts and locales).
